### PR TITLE
Upgraded to Python 3.11

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -125,7 +125,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       CodeUri: lambdas/list-sources
       Timeout: 30
       Policies:
@@ -152,7 +152,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       CodeUri: lambdas/process-channel
       Timeout: 60
       Policies:
@@ -180,7 +180,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       CodeUri: lambdas/process-item
       Timeout: 15
       Policies:


### PR DESCRIPTION
Python 3.8 is on the path to [deprecation by 14 October 2024](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). I've updated the runtime in the YAML file and tested this in my own environment to be working as expected between 3.8 and 3.11.

Feel free to comment or reach out if there's any questions or issues.

